### PR TITLE
Prefer system 1Password CLI over Nix package for non-NixOS compatibility

### DIFF
--- a/src/Shh/Nix.hs
+++ b/src/Shh/Nix.hs
@@ -3,24 +3,12 @@ module Shh.Nix (loadExeNix) where
 
 import Language.Haskell.TH
 import Shh.Internal (rawExe)
-import System.Directory (doesFileExist)
 import System.Which (staticWhichNix)
 
 -- Load an executable in PATH assuming it is in /nix/store. Uses staticWhichNix under the hood.
--- For 'op', it prefers /usr/bin/op if it exists (for non-NixOS compatibility).
 loadExeNix :: String -> String -> Q [Dec]
 loadExeNix fnName exeName = do
-  -- Special case: prefer /usr/bin/op over nix package on non-NixOS systems
-  if exeName == "op"
-    then do
-      usrBinExists <- runIO $ doesFileExist "/usr/bin/op"
-      if usrBinExists
-        then rawExe fnName "/usr/bin/op"
-        else fallbackToNix
-    else fallbackToNix
-  where
-    fallbackToNix = do
-      pathExp <- staticWhichNix exeName
-      case pathExp of
-        LitE (StringL nixStorePath) -> rawExe fnName nixStorePath
-        _ -> fail $ "staticWhichNix didn't return a string literal for " ++ exeName
+  pathExp <- staticWhichNix exeName
+  case pathExp of
+    LitE (StringL nixStorePath) -> rawExe fnName nixStorePath
+    _ -> fail $ "staticWhichNix didn't return a string literal for " ++ exeName


### PR DESCRIPTION
> [!NOTE]
> This PR description was initially generated by an LLM.

This PR improves compatibility with non-NixOS systems by preferring the system-installed 1Password CLI (`/usr/bin/op`) over the Nix package when available.

## User-Facing Changes

- The `hackage-publish` tool will now automatically use `/usr/bin/op` if it exists on the system, falling back to the Nix-provided binary otherwise
- No user action required - the tool will automatically detect and use the appropriate binary at runtime

## Developer Notes

- Added `opBin` function in `src/Main.hs` that performs a runtime check for `/usr/bin/op`
- The Nix package `pkgs._1password-cli` may not work reliably on non-NixOS systems, so this provides a more robust solution
- The check happens at runtime (not compile-time), ensuring the binary is correctly selected regardless of where the tool was built